### PR TITLE
ci: run tests on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,13 +3,6 @@ name: Bump admin portal test
 on:
   pull_request:
     types: [ opened, synchronize ]
-    paths:
-      - 'androidapp/**'
-      - 'quarkusapp/**'
-      - '.github/workflows/test.yml'
-      - 'build.gradle.kts'
-      - 'settings.gradle.kts'
-      - 'gradle/**'
   push:
     branches:
       - main


### PR DESCRIPTION
Removes the `paths:` filter from the `pull_request` trigger.

`jvm-tests` is a required status check on `main`, but the workflow only fired for PRs touching `androidapp/**`, `quarkusapp/**`, or the gradle files. Any PR outside those paths (#190 renovate.json, #129 ROADMAP.md) never triggered the workflow, so the required check never reported and the PR sat at `BLOCKED` with nothing red to fix.

Cost is a couple of CI minutes on doc-only PRs. Renovate PRs touch gradle files anyway, so real coverage is unchanged.

Existing blocked PRs need a push (or close/reopen) after this merges to pick up the new trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)